### PR TITLE
issue-361 : Updated link of kafka source bundle in dockerfiles

### DIFF
--- a/build/Kafka/Dockerfiles/Dockerfile.kafka
+++ b/build/Kafka/Dockerfiles/Dockerfile.kafka
@@ -35,7 +35,7 @@ RUN apt-get update -q=3 && apt-get -q install -q=3 -y \
 
 RUN if [ -z "$ODIMRA_USER_ID" ] || [ -z "$ODIMRA_GROUP_ID" ]; then echo "\n[$(date)] -- ERROR -- ODIMRA_USER_ID or ODIMRA_GROUP_ID is not set\n"; exit 1; fi \
 	&& mkdir -p /opt/kafka/conf /opt/kafka/data /opt/kafka/scripts /kafka/tmp \
-        && export KAFKA_IMAGE_URL=http://www-us.apache.org/dist/kafka/2.5.0/kafka_2.12-2.5.0.tgz \
+        && export KAFKA_IMAGE_URL=https://archive.apache.org/dist/kafka/2.5.0/kafka_2.12-2.5.0.tgz \
         && export KAFKA_IMAGE_NAME=kafka_2.12-2.5.0.tgz \
         && wget -q $KAFKA_IMAGE_URL -P /kafka/ \
         && tar -xzf /kafka/${KAFKA_IMAGE_NAME} --strip-components 1 -C /kafka/tmp \

--- a/build/Kafka/Dockerfiles/Dockerfile.zookeeper
+++ b/build/Kafka/Dockerfiles/Dockerfile.zookeeper
@@ -37,7 +37,7 @@ RUN apt-get update -q=3 && apt-get -q install -q=3 -y \
 
 RUN if [ -z "$ODIMRA_USER_ID" ] || [ -z "$ODIMRA_GROUP_ID" ]; then echo "\n[$(date)] -- ERROR -- ODIMRA_USER_ID or ODIMRA_GROUP_ID is not set\n"; exit 1; fi \
 	&& mkdir -p /opt/zookeeper/data /opt/zookeeper/conf /opt/zookeeper/scripts /zookeeper/tmp \
-	&& export KAFKA_IMAGE_URL=http://www-us.apache.org/dist/kafka/2.5.0/kafka_2.12-2.5.0.tgz \
+	&& export KAFKA_IMAGE_URL=https://archive.apache.org/dist/kafka/2.5.0/kafka_2.12-2.5.0.tgz \
 	&& export KAFKA_IMAGE_NAME=kafka_2.12-2.5.0.tgz \
 	&& wget -q $KAFKA_IMAGE_URL -P /zookeeper/ \
 	&& tar -xzf /zookeeper/${KAFKA_IMAGE_NAME} --strip-components 1 -C /zookeeper/tmp \

--- a/install/Docker/dockerfiles/Dockerfile.kafka
+++ b/install/Docker/dockerfiles/Dockerfile.kafka
@@ -33,7 +33,7 @@ RUN apt-get update -q=3 && apt-get -q install -q=3 -y \
 
 RUN if [ -z "$ODIMRA_USER_ID" ] || [ -z "$ODIMRA_GROUP_ID" ]; then echo "\n[$(date)] -- ERROR -- ODIMRA_USER_ID or ODIMRA_GROUP_ID is not set\n"; exit 1; fi \
 	&& mkdir -p /opt/kafka/conf /opt/kafka/data /opt/kafka/scripts /kafka/tmp \
-        && export KAFKA_IMAGE_URL=http://www-us.apache.org/dist/kafka/2.5.0/kafka_2.12-2.5.0.tgz \
+        && export KAFKA_IMAGE_URL=https://archive.apache.org/dist/kafka/2.5.0/kafka_2.12-2.5.0.tgz \
         && export KAFKA_IMAGE_NAME=kafka_2.12-2.5.0.tgz \
         && wget -q $KAFKA_IMAGE_URL -P /kafka/ \
         && tar -xzf /kafka/${KAFKA_IMAGE_NAME} --strip-components 1 -C /kafka/tmp \

--- a/install/Docker/dockerfiles/Dockerfile.zookeeper
+++ b/install/Docker/dockerfiles/Dockerfile.zookeeper
@@ -34,7 +34,7 @@ RUN apt-get update -q=3 && apt-get -q install -q=3 -y \
 
 RUN if [ -z "$ODIMRA_USER_ID" ] || [ -z "$ODIMRA_GROUP_ID" ]; then echo "\n[$(date)] -- ERROR -- ODIMRA_USER_ID or ODIMRA_GROUP_ID is not set\n"; exit 1; fi \
 	&& mkdir -p /opt/zookeeper/data /opt/zookeeper/conf /opt/zookeeper/scripts /zookeeper/tmp \
-	&& export KAFKA_IMAGE_URL=http://www-us.apache.org/dist/kafka/2.5.0/kafka_2.12-2.5.0.tgz \
+	&& export KAFKA_IMAGE_URL=https://archive.apache.org/dist/kafka/2.5.0/kafka_2.12-2.5.0.tgz \
 	&& export KAFKA_IMAGE_NAME=kafka_2.12-2.5.0.tgz \
 	&& wget -q $KAFKA_IMAGE_URL -P /zookeeper/ \
 	&& tar -xzf /zookeeper/${KAFKA_IMAGE_NAME} --strip-components 1 -C /zookeeper/tmp \


### PR DESCRIPTION
kafka_2.12-2.5.0 source bundle used for creating kafka and zookeeper docker images, has been moved to archived release area and the same needs to be updated in kafka and zookeeper docker files.
Current link used: http://www-us.apache.org/dist/kafka/2.5.0/kafka_2.12-2.5.0.tgz
New Link : https://archive.apache.org/dist/kafka/2.5.0/kafka_2.12-2.5.0.tgz